### PR TITLE
Bste/sboperation monad

### DIFF
--- a/lib/sboperation/fail/index.ts
+++ b/lib/sboperation/fail/index.ts
@@ -1,0 +1,8 @@
+import { SbOperation } from "../types"
+import { left } from "../../either"
+
+type Fail = (error: string) => SbOperation<never>
+
+const fail: Fail = error => left([error])
+
+export default fail

--- a/lib/sboperation/flatMap/index.test.ts
+++ b/lib/sboperation/flatMap/index.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "vitest"
+import * as fc from "fast-check"
+import { pipe } from "../../functions"
+import flatMap from "."
+import { some } from "../../option"
+import { right } from "../../either"
+
+describe("SBOperation flatMap", () => {
+	const f = (x: number) => right(some(x + 1))
+
+	test("left identity", () => {
+		fc.assert(
+			fc.property(fc.integer(), value => {
+				const pure = right(some(value))
+
+				expect(pipe(pure, flatMap(f))).toEqual(f(value))
+			}),
+		)
+	})
+
+	test("right identity", () => {
+		fc.assert(
+			fc.property(fc.anything(), value => {
+				const pure = right(some(value))
+
+				expect(
+					pipe(
+						pure,
+						flatMap(_ => right(some(_))),
+					),
+				).toEqual(pure)
+			}),
+		)
+	})
+
+	test("associativity", () => {
+		fc.assert(
+			fc.property(fc.integer(), a => {
+				const pure = right(some(a))
+
+				const lhs = pipe(pipe(pure, flatMap(f)), flatMap(f))
+				const rhs = pipe(
+					pure,
+					flatMap(_ => pipe(f(_), flatMap(f))),
+				)
+
+				expect(lhs).toEqual(rhs)
+			}),
+		)
+	})
+})

--- a/lib/sboperation/flatMap/index.ts
+++ b/lib/sboperation/flatMap/index.ts
@@ -1,0 +1,16 @@
+import { isLeft } from "../../either"
+import { isNone } from "../../option"
+import { SbOperation } from "../types"
+
+type FlatMap = <A, B>(
+	f: (a: A) => SbOperation<B>,
+) => (self: SbOperation<A>) => SbOperation<B>
+
+const flatMap: FlatMap = f => self =>
+	isLeft(self)
+		? (self as any)
+		: isNone(self.right)
+			? (self as any)
+			: f(self.right.value)
+
+export default flatMap

--- a/lib/sboperation/fromEither/index.test.ts
+++ b/lib/sboperation/fromEither/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from "vitest"
+import * as fc from "fast-check"
+import { left, right } from "../../either"
+import fromEither from "../fromEither"
+import { some } from "../../option"
+
+describe("SBOperation fromEither", () => {
+	test("right", () => {
+		fc.assert(
+			fc.property(fc.anything(), value => {
+				const either = right(value)
+				expect(fromEither(either)).toEqual(right(some(value)))
+			}),
+		)
+	})
+
+	test("left", () => {
+		fc.assert(
+			fc.property(fc.array(fc.string()), value => {
+				const either = left(value)
+
+				expect(fromEither(either)).toEqual(either)
+			}),
+		)
+	})
+})

--- a/lib/sboperation/fromEither/index.ts
+++ b/lib/sboperation/fromEither/index.ts
@@ -1,0 +1,10 @@
+import { Either, isLeft, right } from "../../either"
+import { some } from "../../option"
+import { SbOperation } from "../types"
+
+type FromEither = <A>(e: Either<string[], A>) => SbOperation<A>
+
+const fromEither: FromEither = e =>
+	isLeft(e) ? (e as any) : right(some(e.right))
+
+export default fromEither

--- a/lib/sboperation/fromOption/index.test.ts
+++ b/lib/sboperation/fromOption/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect } from "vitest"
+import * as fc from "fast-check"
+import { right } from "../../either"
+import { none, some } from "../../option"
+import fromOption from "."
+
+describe("SBOperation fromOption", () => {
+	test("some", () => {
+		fc.assert(
+			fc.property(fc.anything(), value => {
+				const opt = some(value)
+				expect(fromOption(opt)).toEqual(right(opt))
+			}),
+		)
+	})
+
+	test("none", () => {
+		expect(fromOption(none)).toEqual(right(none))
+	})
+})

--- a/lib/sboperation/fromOption/index.ts
+++ b/lib/sboperation/fromOption/index.ts
@@ -1,0 +1,9 @@
+import { SbOperation } from "../types"
+import { Option } from "../../option"
+import { right } from "../../either"
+
+type FromOption = <A>(o: Option<A>) => SbOperation<A>
+
+const fromOption: FromOption = o => right(o)
+
+export default fromOption

--- a/lib/sboperation/map/index.test.ts
+++ b/lib/sboperation/map/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "vitest"
+import * as fc from "fast-check"
+import map from "."
+import { identity, pipe } from "../../functions"
+import { some } from "../../option"
+import { right } from "../../either"
+
+describe("SBOperation map", () => {
+	test("identity", () => {
+		fc.assert(
+			fc.property(fc.anything(), value => {
+				const option = right(some(value))
+				expect(map(identity)(option)).toEqual(option)
+			}),
+		)
+	})
+
+	test("composition", () => {
+		fc.assert(
+			fc.property(fc.integer(), value => {
+				const inc = (n: number) => n + 1
+				const option = right(some(value))
+
+				const piped = pipe(option, map(inc), map(inc))
+
+				const composed = pipe(
+					option,
+					map(n => inc(inc(n))),
+				)
+
+				expect(piped).toEqual(composed)
+			}),
+		)
+	})
+})

--- a/lib/sboperation/map/index.ts
+++ b/lib/sboperation/map/index.ts
@@ -1,0 +1,10 @@
+import { pipe } from "../../functions"
+import { map as eMap } from "../../either"
+import { map as oMap } from "../../option"
+import { SbOperation } from "../types"
+
+type Map = <A, B>(f: (a: A) => B) => (self: SbOperation<A>) => SbOperation<B>
+
+const map: Map = f => self => pipe(self, eMap(oMap(f)))
+
+export default map

--- a/lib/sboperation/of/index.ts
+++ b/lib/sboperation/of/index.ts
@@ -1,0 +1,9 @@
+import { right } from "../../either"
+import { some } from "../../option"
+import { SbOperation } from "../types"
+
+type Of = <A>(a: A) => SbOperation<A>
+
+const of: Of = a => right(some(a))
+
+export default of

--- a/lib/sboperation/types.ts
+++ b/lib/sboperation/types.ts
@@ -1,0 +1,4 @@
+import { Either } from "../either"
+import { Option } from "../option"
+
+export type SbOperation<A> = Either<string[], Option<A>>


### PR DESCRIPTION
The failure type is fixed to `string[]` at the moment, we can add in a better error type later on.