### PR TITLE
proposal: infer tuple members in sequenced types

### DIFF
--- a/lib/either/sequence/index.test.ts
+++ b/lib/either/sequence/index.test.ts
@@ -1,9 +1,10 @@
-import { expect, test } from "vitest"
+import { expect, expectTypeOf, test } from "vitest"
 
 import left from "../left"
 import right from "../right"
 
 import sequence from "."
+import { Either } from "../types"
 
 test("[sequence] (either) returns left if contains left", () => {
 	expect(
@@ -15,4 +16,17 @@ test("[sequence] (either) returns Option<Array<T>> from Array<Option<T>>", () =>
 	expect(sequence([right(5), right(1), right(7), right(3), right(9)])).toEqual(
 		right([5, 1, 7, 3, 9]),
 	)
+})
+
+test("[sequence] (either) returns typed heterogenous array", () => {
+	const result = sequence([
+		right(1),
+		right(true),
+		right("hello"),
+		right({ a: "a" }),
+	])
+
+	expectTypeOf(result).toMatchTypeOf<
+		Either<unknown, [number, boolean, string, { a: string }]>
+	>()
 })

--- a/lib/either/sequence/index.ts
+++ b/lib/either/sequence/index.ts
@@ -1,11 +1,14 @@
-import { Either } from "../types"
+import { Either, InferEitherTuple } from "../types"
 
 import identity from "../../functions/identity"
 import pipe from "../../functions/pipe"
 import traverse from "../traverse"
 
-type Sequence = <E, A>(self: Array<Either<E, A>>) => Either<E, Array<A>>
-
-const sequence: Sequence = self => pipe(self, traverse(identity))
+function sequence<E, T extends Array<Either<E, any>>>(
+	self: [...T],
+): Either<E, InferEitherTuple<T>>
+function sequence<E, U>(self: Array<Either<E, U>>) {
+	return pipe(self, traverse(identity))
+}
 
 export default sequence

--- a/lib/either/types.ts
+++ b/lib/either/types.ts
@@ -8,4 +8,8 @@ export interface Right<A> {
 	readonly right: A
 }
 
+export type InferEitherTuple<T extends Array<Either<any, any>>> = {
+	[K in keyof T]: T[K] extends Either<any, infer U> ? U : never
+}
+
 export type Either<E, A> = Left<E> | Right<A>


### PR DESCRIPTION
Currently when we sequence a list of monads we are restricted to a single wrapped type, e.g we could only sequence and preserve the output type of a list of `Either<string, boolean>`.
A list of `[Either<string, boolean>, Either<string, number>]` would yield a result type of `Array<Either<string, boolean | number>>` which isn't very useful for when we operate over the result list.

This change would let us do: 
```ts
pipe(
  [right(1), right("hello"), right(false)],
  sequence,
  map(([a, b, c]) => { //...do stuff })
)
```
and have the `[a, b, c]` types correctly inferred as `[number, string, boolean]`.  This is useful for when we have a bunch of validations, for example, that have operated over different types and we want to collect and do something with the result.